### PR TITLE
Link up libraries in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 React.js components as native HTML elements
 ===========================================
 
-Tiny Google Polymer or Mozilla X-Tag add-on which allows to use React.js components as custom HTML elements. Also works with native custom elements implementation if present.
+Tiny Google [Polymer](http://polymer-project.org) or Mozilla [X-Tags](http://www.x-tags.org/) add-on which allows to use [React.js](http://facebook.github.io/react/) components as [custom HTML elements](http://w3c.github.io/webcomponents/spec/custom/). Also works with a native Custom Elements implementation if present.
 
 [Demo](http://pixelscommander.com/polygon/reactive-elements/example/)
 


### PR DESCRIPTION
Polymer, X-Tags, React and the Custom Element specs aren’t linked to
from the README. This links them up appropriately.
