### PR TITLE
Add ability to pass JSON object as attribute value.

### DIFF
--- a/src/reactive-elements.js
+++ b/src/reactive-elements.js
@@ -103,11 +103,12 @@
     }
 
     var parseAttributeValue = function (value) {
-        var regexp = /\{.*?\}/g;
+        var regexp = /^\{.*?\}$/;
         var matches = value.match(regexp);
 
         if (matches !== null && matches !== undefined && matches.length > 0) {
-            value = eval(matches[0].replace('{', '').replace('}', ''));
+            //drop leading/trailing braces
+            value = JSON.parse(matches[0].slice(1, matches[0].length - 1));
         }
 
         return value;


### PR DESCRIPTION
With changes introduced in this pull request it is possible
1) pass JSON object as attribute value
2) attribute value can contain braces

Also I've replaced eval with JSON.parse, I think it is save to assume that attribute contains static value that we just need to parse, not to evaluate.

I would like to add some tests for these cases, but as of now there is no tests infrastructure at all. Any plans with regards to test?