### PR TITLE
Correct data attribute test

### DIFF
--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -49,7 +49,7 @@ describe("utils", function() {
         });
 
         it("should convert attributes containing 'data-' not as a prefix to React properties", function(){
-            expect(window.ReactiveElements.utils.attributeNameToPropertyName('attribute-data')).toEqual('attributeData');
+            expect(window.ReactiveElements.utils.attributeNameToPropertyName('attribute-data-test')).toEqual('attributeDataTest');
         });
     });
 });


### PR DESCRIPTION
The attribute in the testcase for the data attribute only included '-data'
instead of the required 'data-'.