### PR TITLE
using "react-render-html" module to create element children property 

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "dependencies": {
     "document-register-element": "^0.5.0",
     "react": "^15.2.0",
-    "react-dom": "^15.2.0"
+    "react-dom": "^15.2.0",
+    "react-render-html": "^0.1.5"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 var React = window.React || require('react');
+var renderHTML = require('react-render-html');
 
 var getAllProperties = function (obj) {
     var props = {};
@@ -87,11 +88,9 @@ exports.parseAttributeValue = function (value) {
 };
 
 exports.getChildren = function (el) {
-    var fragment = document.createDocumentFragment();
-    while (el.childNodes.length) {
-        fragment.appendChild(el.childNodes[0]);
-    }
-    return fragment;
+    var html = el.innerHTML;
+    el.innerHTML = "";
+    return renderHTML(html);
 };
 
 exports.shallowCopy = function (a, b) {


### PR DESCRIPTION
when creating react element the getChildren method result to the error "If you meant to render a collection of children, use an array instead or wrap the object using createFragment(object) from the React add-ons."  i could solve this issue using the "react-render-html" module that create react elements from html string.
