### PR TITLE
Fix multiple attribute changes

### DIFF
--- a/src/reactive-elements.js
+++ b/src/reactive-elements.js
@@ -40,11 +40,7 @@
         };
 
         elementPrototype.attributeChangedCallback = function (name, oldValue, newValue) {
-            var propertyName = utils.attributeNameToPropertyName(name),
-                value = utils.parseAttributeValue(newValue);
-
-            var props = utils.shallowCopy({}, this.props);
-            props[propertyName] = value;
+            var props = utils.getProps(this);
             reactElement = create(this, props);
         };
 


### PR DESCRIPTION
Issue: When you change multiple attributes on a ReactiveElement eg `<my-el a="1" b="1" />` using `$('my-el').attr('a', 2).attr('b', 2)` only the last attribute change will be reflected in the props of the React component.

This fix works as expected to update all props of a component.