### PR TITLE
update react to version 16 and document register element to version 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,10 @@
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "document-register-element": "^0.5.0",
-    "react": "^15.2.0",
-    "react-dom": "^15.2.0"
+    "document-register-element": "^1.7.2"
+  },
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "karma-jasmine": "^1.0.2",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "webpack": "^1.13.1"
   },
   "dependencies": {


### PR DESCRIPTION
Resolves
```
Uncaught Error: Unable to find node on an unmounted component.
```
when using ReactiveElements with React 16.
See https://github.com/Pomax/react-onclickoutside/issues/231#issuecomment-333174275.

---

Unit tests are passing, I `npm linked` the updated version locally and it passes smoke tests on existing elements.