### PR TITLE
ci: add travis ci for continuous integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - lts/* # latest LTS release
+  - node # latest stable release
+addons:
+  chrome: stable
+script: npm test -- --browsers ChromeHeadlessNoSandbox # https://docs.travis-ci.com/user/chrome#Sandboxing

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,75 +1,68 @@
 // Karma configuration
 // Generated on Wed Feb 11 2015 12:13:53 GMT+0100 (CET)
 module.exports = function(config) {
-  config.set({
+    config.set({
+        // base path that will be used to resolve all patterns (eg. files, exclude)
+        basePath: "",
 
-    // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
+        // frameworks to use
+        // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+        frameworks: ["jasmine"],
 
+        // list of files / patterns to load in the browser
+        files: ["test/unit.spec.js"],
 
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine'],
+        // list of files to exclude
+        exclude: [],
 
+        plugins: [
+            require("karma-webpack"),
+            "karma-sourcemap-loader",
+            "karma-chrome-launcher",
+            "karma-jasmine"
+        ],
 
-    // list of files / patterns to load in the browser
-    files: [
-        'test/unit.spec.js'
-    ],
+        // preprocess matching files before serving them to the browser
+        // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+        preprocessors: {
+            "test/unit.spec.js": ["webpack", "sourcemap"]
+        },
 
+        // test results reporter to use
+        // possible values: 'dots', 'progress'
+        // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+        reporters: ["progress"],
 
-    // list of files to exclude
-    exclude: [
-    ],
+        // web server port
+        port: 9876,
 
-    plugins: [
- 		require('karma-webpack'),
- 		'karma-sourcemap-loader',
-		'karma-chrome-launcher',
-		'karma-jasmine'
-    ],
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
 
+        // level of logging
+        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
 
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-        'test/unit.spec.js': ['webpack', 'sourcemap']
-    },
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
 
+        // start these browsers
+        // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+        browsers: ["Chrome"],
 
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+        // https://docs.travis-ci.com/user/chrome#Sandboxing
+        customLaunchers: {
+            ChromeHeadlessNoSandbox: {
+                base: "ChromeHeadless",
+                flags: ["--no-sandbox"]
+            }
+        },
 
-
-    // web server port
-    port: 9876,
-
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
-
-
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
-
-
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
-
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true,
-    webpackMiddleware: {
-        noInfo: true
-    }
-  });
+        // Continuous Integration mode
+        // if true, Karma captures browsers, runs the tests and exits
+        singleRun: true,
+        webpackMiddleware: {
+            noInfo: true
+        }
+    });
 };

--- a/package.json
+++ b/package.json
@@ -71,13 +71,13 @@
     "email": "denis.radin@gmail.com"
   },
   "devDependencies": {
-    "jasmine": "^2.4.1",
-    "jasmine-core": "^2.4.1",
-    "karma": "^1.1.1",
-    "karma-chrome-launcher": "^0.1.12",
-    "karma-jasmine": "^1.0.2",
+    "jasmine": "^3.0.0",
+    "jasmine-core": "^3.0.0",
+    "karma": "^2.0.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-jasmine": "^1.1.2",
     "karma-sourcemap-loader": "^0.3.7",
-    "karma-webpack": "^1.7.0",
+    "karma-webpack": "^2.0.0",
     "webpack": "^1.13.1"
   },
   "dependencies": {


### PR DESCRIPTION
Adds Travis CI configuration to enable automatic testing of pull requests.
Example build: https://travis-ci.org/ChristianMurphy/ReactiveElements/builds/375087188

:notebook: Note: Travis CI would still need to be enabled for the repository https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI