### PR TITLE
Stop empty string attr being passed as `null`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -85,7 +85,7 @@ exports.attributeNameToPropertyName = function(attributeName) {
 };
 
 exports.parseAttributeValue = function(value, transformOptions) {
-  if (!value) {
+  if (value == undefined) {
     return null;
   }
 

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -26,6 +26,11 @@ describe('utils', function() {
       expect(jsonDeserialized.language).toEqual('javascript');
     });
 
+    it('should pass through the empty string', function() {
+      var emptyStringAttr = ReactiveElements.utils.parseAttributeValue('');
+      expect(emptyStringAttr).toEqual('');
+    });
+
     it("should convert string 'true' to boolean", function() {
       var boolAttr = ReactiveElements.utils.parseAttributeValue('true');
       expect(boolAttr).toEqual(true);


### PR DESCRIPTION
This fix ensures any empty string attrs are passed to React as that.