### PR TITLE
Make the shadow root optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ Subscribing to DOM events is similar:
 React.findDOMNode(this).addEventListener('change', function(e){...});
 ```
 
+## Options
+
+You can also specify options to the `ReactiveElements` call, e.g.
+
+```js
+ReactiveElements('welcome-component', Welcome, options);
+```
+
+### `options.useShadowDom` _(default `false`)_
+
+By default, your React element is rendered directly into the web-component root. However, by setting this option - your React element will instead be rendered in a [Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) inside the web-component instead.
+
 ## Dependencies
 
 - [React.js](https://github.com/facebook/react)


### PR DESCRIPTION
The shadow DOM feature is cool, but it's pretty restrictive as a default

By being in a shadow DOM you cannot access CSS styles added to the document root (which your React project will be extracting to, if you're using something like `ExtractTextPlugin`)