### PR TITLE
Remove the mutation observer feature

### DIFF
--- a/src/reactive-elements.js
+++ b/src/reactive-elements.js
@@ -22,20 +22,6 @@ function reactiveElements(elementName, ReactComponent, options) {
       const self = super();
 
       self.attachShadow({ mode: 'open' });
-
-      const observer = new MutationObserver(() => {
-        ReactDOM.unmountComponentAtNode(self.shadowRoot);
-        const props = utils.getProps(self);
-        props.children = utils.getChildren(self);
-        create(self, props);
-      });
-
-      observer.observe(self, {
-        childList: true,
-        subtree: true,
-        characterData: true,
-        attributes: true,
-      });
     }
 
     connectedCallback() {


### PR DESCRIPTION
The mutation observer idea is cool, but largely unnecessary - there shouldn't be much dynamism on the web-component side of your web-component/React bridge. The dynamic stuff should really all be living on the React side of stuff.

But more specifically, the code is a little buggy as things stand; when a component re-mounts, the code to determine the element's children does not calculate them correctly (possibly just if the remount is near the initial mount?), and instead determines the children array to always be `[]`

So it seems that the easiest fix is probably just to remove it entirely